### PR TITLE
Add '+' character to regex for codeblock language

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ const rules = {
 		}
 	}),
 	codeBlock: Object.assign({ }, markdown.defaultRules.codeBlock, {
-		match: markdown.inlineRegex(/^```(([a-z0-9-]+?)\n+)?\n*([^]+?)\n*```/i),
+		match: markdown.inlineRegex(/^```(([a-z0-9-+]+?)\n+)?\n*([^]+?)\n*```/i),
 		parse: function(capture, parse, state) {
 			return {
 				lang: (capture[2] || '').trim(),


### PR DESCRIPTION
This allows recognising (and thus highlighting) a codeblock with C++ as
the specified language.